### PR TITLE
fix: treat empty user_id values as None

### DIFF
--- a/docker/v4/export.json
+++ b/docker/v4/export.json
@@ -24,6 +24,18 @@
       "impressionData": false,
       "archivedAt": null,
       "archived": false
+    },
+    {
+      "name": "test-userid-stickiness",
+      "description": "",
+      "type": "experiment",
+      "project": "default",
+      "stale": false,
+      "createdAt": "2023-04-20T18:39:05.489Z",
+      "lastSeenAt": null,
+      "impressionData": false,
+      "archivedAt": null,
+      "archived": false
     }
   ],
   "strategies": [],
@@ -49,6 +61,20 @@
       "environment": "development",
       "strategyName": "default",
       "parameters": {},
+      "constraints": [],
+      "createdAt": "2023-04-20T18:39:14.923Z"
+    },
+    {
+      "id": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+      "featureName": "test-userid-stickiness",
+      "projectId": "default",
+      "environment": "development",
+      "strategyName": "flexibleRollout",
+      "parameters": {
+        "groupId": "test-userid-stickiness",
+        "rollout": "100",
+        "stickiness": "userId"
+      },
       "constraints": [],
       "createdAt": "2023-04-20T18:39:14.923Z"
     }
@@ -114,6 +140,18 @@
     {
       "enabled": false,
       "featureName": "test-toggle-2",
+      "environment": "production",
+      "variants": []
+    },
+    {
+      "enabled": true,
+      "featureName": "test-userid-stickiness",
+      "environment": "development",
+      "variants": []
+    },
+    {
+      "enabled": false,
+      "featureName": "test-userid-stickiness",
       "environment": "production",
       "variants": []
     }

--- a/docker/v5/export.json
+++ b/docker/v5/export.json
@@ -24,6 +24,18 @@
       "impressionData": false,
       "archivedAt": null,
       "archived": false
+    },
+    {
+      "name": "test-userid-stickiness",
+      "description": null,
+      "type": "experiment",
+      "project": "default",
+      "stale": false,
+      "createdAt": "2024-07-12T12:56:00.000Z",
+      "lastSeenAt": null,
+      "impressionData": false,
+      "archivedAt": null,
+      "archived": false
     }
   ],
   "strategies": [],
@@ -82,6 +94,23 @@
       "constraints": [],
       "variants": [],
       "createdAt": "2024-07-12T12:55:49.424Z",
+      "disabled": false
+    },
+    {
+      "id": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+      "featureName": "test-userid-stickiness",
+      "projectId": "default",
+      "environment": "development",
+      "strategyName": "flexibleRollout",
+      "title": null,
+      "parameters": {
+        "groupId": "test-userid-stickiness",
+        "rollout": "100",
+        "stickiness": "userId"
+      },
+      "constraints": [],
+      "variants": [],
+      "createdAt": "2024-07-12T12:56:00.000Z",
       "disabled": false
     }
   ],
@@ -148,6 +177,18 @@
           "weightType": "variable"
         }
       ]
+    },
+    {
+      "enabled": false,
+      "featureName": "test-userid-stickiness",
+      "environment": "production",
+      "variants": []
+    },
+    {
+      "enabled": true,
+      "featureName": "test-userid-stickiness",
+      "environment": "development",
+      "variants": []
     }
   ],
   "segments": [],

--- a/docker/v6/export.json
+++ b/docker/v6/export.json
@@ -17,6 +17,15 @@
       "stale": false,
       "impressionData": false,
       "archived": false
+    },
+    {
+      "name": "test-userid-stickiness",
+      "description": null,
+      "type": "experiment",
+      "project": "default",
+      "stale": false,
+      "impressionData": false,
+      "archived": false
     }
   ],
   "featureStrategies": [
@@ -63,6 +72,21 @@
       ],
       "disabled": false,
       "segments": []
+    },
+    {
+      "name": "flexibleRollout",
+      "id": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+      "featureName": "test-userid-stickiness",
+      "title": "",
+      "parameters": {
+        "groupId": "test-userid-stickiness",
+        "rollout": "100",
+        "stickiness": "userId"
+      },
+      "constraints": [],
+      "variants": [],
+      "disabled": false,
+      "segments": []
     }
   ],
   "featureEnvironments": [
@@ -79,6 +103,13 @@
       "environment": "development",
       "variants": [],
       "name": "test-toggle-2"
+    },
+    {
+      "enabled": true,
+      "featureName": "test-userid-stickiness",
+      "environment": "development",
+      "variants": [],
+      "name": "test-userid-stickiness"
     }
   ],
   "contextFields": [],

--- a/docker/v7/export.json
+++ b/docker/v7/export.json
@@ -17,6 +17,15 @@
       "stale": false,
       "impressionData": false,
       "archived": false
+    },
+    {
+      "name": "test-userid-stickiness",
+      "description": null,
+      "type": "experiment",
+      "project": "default",
+      "stale": false,
+      "impressionData": false,
+      "archived": false
     }
   ],
   "featureStrategies": [
@@ -63,6 +72,21 @@
       ],
       "disabled": false,
       "segments": []
+    },
+    {
+      "name": "flexibleRollout",
+      "id": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+      "featureName": "test-userid-stickiness",
+      "title": "",
+      "parameters": {
+        "groupId": "test-userid-stickiness",
+        "rollout": "100",
+        "stickiness": "userId"
+      },
+      "constraints": [],
+      "variants": [],
+      "disabled": false,
+      "segments": []
     }
   ],
   "featureEnvironments": [
@@ -79,6 +103,13 @@
       "environment": "development",
       "variants": [],
       "name": "test-toggle-2"
+    },
+    {
+      "enabled": true,
+      "featureName": "test-userid-stickiness",
+      "environment": "development",
+      "variants": [],
+      "name": "test-userid-stickiness"
     }
   ],
   "contextFields": [],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,11 +100,15 @@ impl Default for Context<'_> {
 impl Into<UnleashContext> for Context<'_> {
     fn into(self) -> UnleashContext {
         UnleashContext {
-            user_id: self.user_id.map(String::from).or_else(|| {
-                self.jwt
-                    .map(|jwt| decode_jwt(jwt).map(|claims| claims.sub))
-                    .flatten()
-            }),
+            user_id: self
+                .user_id
+                .filter(|user_id| !user_id.is_empty())
+                .map(String::from)
+                .or_else(|| {
+                    self.jwt
+                        .map(|jwt| decode_jwt(jwt).map(|claims| claims.sub))
+                        .flatten()
+                }),
             session_id: self.session_id.map(String::from),
             environment: self.environment.map(String::from),
             app_name: self.app_name.map(String::from),
@@ -369,6 +373,8 @@ mod test {
         Some("userId"), Some(".eyJzdWIiOiIxMjM0NSJ9."), Some("userId"); "should use user_id if present"
     )]
     #[test_case(None, Some(".eyJzdWIiOiIxMjM0NSJ9."), Some("12345"); "should fallback to jwt")]
+    #[test_case(Some(""), Some(".eyJzdWIiOiIxMjM0NSJ9."), Some("12345"); "should fallback to jwt when user_id is empty")]
+    #[test_case(Some(""), None, None; "should return none when user_id is empty and jwt is missing")]
     pub fn test_context_user_id(user_id: Option<&str>, jwt: Option<&str>, expected: Option<&str>) {
         let context = Context {
             user_id,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ varnish::vtc!(test05);
 varnish::vtc!(test06);
 varnish::vtc!(test07);
 varnish::vtc!(test08);
+varnish::vtc!(test09);
 
 const EMPTY_STRING: String = String::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@ varnish::vtc!(test05);
 varnish::vtc!(test06);
 varnish::vtc!(test07);
 varnish::vtc!(test08);
-varnish::vtc!(test09);
 
 const EMPTY_STRING: String = String::new();
 

--- a/tests/test08.vtc
+++ b/tests/test08.vtc
@@ -20,5 +20,5 @@ client c1 {
     delay 0.5
 	txreq -url "/"
 	rxresp
-	expect resp.http.x-toggles == "test-toggle=test-variant,test-toggle-2=test-variant"
+	expect resp.http.x-toggles == "test-toggle=test-variant,test-toggle-2=test-variant,test-userid-stickiness=disabled"
 } -run

--- a/tests/test09.vtc
+++ b/tests/test09.vtc
@@ -1,0 +1,28 @@
+varnishtest "unleash vmod empty user_id falls back to session_id"
+
+server s1 {} -start
+
+varnish v1 -vcl+backend {
+	import unleash from "${vmod}";
+
+    sub vcl_init {
+        new c = unleash.client(
+            url="http://localhost:4242",
+            token="*:development.964a287e1b728cb5f4f3e0120df92cb5");
+	}
+
+	sub vcl_deliver {
+		set resp.http.x-with-user    = c.is_enabled(name="test-userid-stickiness", user_id="some-user", session_id="123456");
+		set resp.http.x-empty-user   = c.is_enabled(name="test-userid-stickiness", user_id="", session_id="123456");
+		set resp.http.x-missing-user = c.is_enabled(name="test-userid-stickiness", session_id="123456");
+	}
+} -start
+
+client c1 {
+    delay 0.5
+	txreq -url "/"
+	rxresp
+	expect resp.http.x-with-user    == "true"
+	expect resp.http.x-empty-user   == "false"
+	expect resp.http.x-missing-user == "false"
+} -run

--- a/tests/test09.vtc
+++ b/tests/test09.vtc
@@ -22,7 +22,7 @@ client c1 {
     delay 0.5
 	txreq -url "/"
 	rxresp
-	expect resp.http.x-with-user    == "true"
-	expect resp.http.x-empty-user   == "false"
+	expect resp.http.x-with-user == "true"
+	expect resp.http.x-empty-user == "false"
 	expect resp.http.x-missing-user == "false"
 } -run


### PR DESCRIPTION
Right now the user_id field can get empty headers, which would be treated as a value. Which means that it is not allowed to fall back to session_id, like it should according to unleash.